### PR TITLE
結合テストの実装

### DIFF
--- a/src/main/java/com/example/lecture09task/service/UserServiceImpl.java
+++ b/src/main/java/com/example/lecture09task/service/UserServiceImpl.java
@@ -50,7 +50,8 @@ public class UserServiceImpl implements UserService {
     }
 
     public void deleteUser(int id) {
-        userMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("This id is not found"));
+        userMapper.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("This id is not found"));
         userMapper.deleteUser(id);
     }
 }

--- a/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
@@ -32,7 +32,7 @@ public class UserRestApiIntegrationTest {
 
     // GETメソッドで存在するIDを指定した時に、指定したIDのユーザーが取得できステータスコード200が返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定したIDのユーザーが取得できること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
@@ -41,8 +41,8 @@ public class UserRestApiIntegrationTest {
 
         JSONAssert.assertEquals("""
                 {
-                "id": 1, 
-                "name": "tanaka", 
+                "id": 1,
+                "name": "tanaka",
                 "age": 25
                 }
             """, response, JSONCompareMode.STRICT);
@@ -50,7 +50,7 @@ public class UserRestApiIntegrationTest {
 
     // GETメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定したIDのユーザーが存在しない時に例外がスローされること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users/4"))
@@ -73,7 +73,7 @@ public class UserRestApiIntegrationTest {
 
     // GETメソッドでクエリパラメータで年齢を指定しない時に、ユーザーが全件取得できステータスコード200が返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 年齢を指定しない時にユーザーが全件取得できること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users"))
@@ -83,27 +83,27 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("""
                     [
                     {
-                    "id": 1, 
-                    "name": "tanaka", 
+                    "id": 1,
+                    "name": "tanaka",
                     "age": 25
-                    }, 
+                    },
                     {
-                    "id": 2, 
-                    "name": "suzuki", 
+                    "id": 2,
+                    "name": "suzuki",
                     "age": 30
-                    }, 
+                    },
                     {
-                    "id": 3, 
-                    "name": "yamada", 
+                    "id": 3,
+                    "name": "yamada",
                     "age": 35
                     }
-                    ]                    
+                    ]
                 """, response, JSONCompareMode.STRICT);
     }
 
     // GETメソッドでDBが空の時に、空のListが返されステータスコード200が返されること
     @Test
-    @DataSet(value = "empty.yml")
+    @DataSet(value = "datasets/empty.yml")
     @Transactional
     void DBが空の時に空のListが返されること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users"))
@@ -111,13 +111,13 @@ public class UserRestApiIntegrationTest {
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""
-                    []                    
-                """, response, JSONCompareMode.STRICT);
+                    []
+                    """, response, JSONCompareMode.STRICT);
     }
 
     // GETメソッドでクエリパラメータで年齢を指定した時に、指定した年齢より上のユーザーが取得できステータスコード200が返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定した年齢より上のユーザーが取得できること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users?age=30"))
@@ -127,8 +127,8 @@ public class UserRestApiIntegrationTest {
         JSONAssert.assertEquals("""
                 [
                 {
-                "id": 3, 
-                "name": "yamada", 
+                "id": 3,
+                "name": "yamada",
                 "age": 35
                 }
                 ]
@@ -137,7 +137,7 @@ public class UserRestApiIntegrationTest {
 
     // GETメソッドでクエリパラメータで年齢を指定し指定した年齢より上のユーザーが存在しない時に、空のListとステータスコード200が返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 指定した年齢より上のユーザーが存在しない時に空のListが返されること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.get("/users?age=35"))
@@ -151,7 +151,7 @@ public class UserRestApiIntegrationTest {
 
     // POSTメソッドで正しくリクエストした時に、ユーザーが登録できステータスコード201とメッセージが返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @ExpectedDataSet(value = "datasets/insert_users.yml", ignoreCols = "id")
     @Transactional
     void ユーザーが登録できること() throws Exception{
@@ -159,7 +159,7 @@ public class UserRestApiIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content("""
                         {
-                        "name": "takahashi", 
+                        "name": "takahashi",
                         "age": 40
                         }
                         """))
@@ -175,14 +175,14 @@ public class UserRestApiIntegrationTest {
 
     // POSTメソッドでリクエストのnameがnullの時に、ステータスコード400とエラーメッセージが返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 登録時のリクエストのnameがnullの時にエラーメッセージが返されること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/users")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content("""
                         {
-                        "name": null, 
+                        "name": null,
                         "age": 40
                         }
                         """))
@@ -205,14 +205,14 @@ public class UserRestApiIntegrationTest {
 
     // POSTメソッドでリクエストのageがnullの時に、ステータスコード400とエラーメッセージが返されること
     @Test
-    @DataSet(value = "users.yml")
+    @DataSet(value = "datasets/users.yml")
     @Transactional
     void 登録時のリクエストのageがnullの時にエラーメッセージが返されること() throws Exception{
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/users")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content("""
                         {
-                        "name": "takahashi", 
+                        "name": "takahashi",
                         "age": null
                         }
                         """))
@@ -234,12 +234,106 @@ public class UserRestApiIntegrationTest {
     }
 
     // PATCHメソッドで存在するIDを指定した時に、ユーザーが更新できステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/update_users.yml")
+    @Transactional
+    void ユーザーが更新できること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/users/3")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                        {
+                        "name": "takahashi",
+                        "age": 40
+                        }
+                        """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+            {
+            "message": "user successfully updated"
+            }
+            """, response, JSONCompareMode.STRICT);
+    }
 
     // PATCHメソッドで存在するIDを指定しリクエストのnameがnullの時に、ageのみ更新されステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/update_users_age.yml")
+    @Transactional
+    void 更新リクエストでnameがnullの時ageのみ更新されること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/users/3")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                        {
+                        "name": null,
+                        "age": 40
+                        }
+                        """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+            {
+            "message": "user successfully updated"
+            }
+            """, response, JSONCompareMode.STRICT);
+    }
 
     // PATCHメソッドで存在するIDを指定しリクエストのageがnullの時に、nameのみ更新されステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/update_users_name.yml")
+    @Transactional
+    void 更新リクエストでageがnullの時nameのみ更新されること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/users/3")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                        {
+                        "name": "takahashi",
+                        "age": null
+                        }
+                        """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+            {
+            "message": "user successfully updated"
+            }
+            """, response, JSONCompareMode.STRICT);
+    }
 
     // PATCHメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 更新リクエストで指定したIDのユーザーが存在しない時に例外がスローされること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.patch("/users/4")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("""
+                        {
+                        "name": "takahashi",
+                        "age": "40"
+                        }
+                        """))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    {
+                    "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                    "status": "404",
+                    "error": "Not Found",
+                    "message": "This id is not found",
+                    "path": "/users/4"
+                    }
+                """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
 
     // DELETEメソッドで存在するIDを指定した時に、ユーザーが削除できステータスコード200とメッセージが返されること
 

--- a/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.example.lecture09task.integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+
+public class UserRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    // GETメソッドで存在するIDを指定した時に、指定したIDのユーザーが取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void 指定したIDのユーザーが取得できること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                "id": 1, 
+                "name": "tanaka", 
+                "age": 25
+                }
+            """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void 指定したIDのユーザーが存在しない時に例外がスローされること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users/4"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    {
+                    "timestamp": ZonedDateTime.now().toString(),
+                    "status": "404",
+                    "error": "Not Found",
+                    "message": "This id is not found",
+                    "path": "/users/4"
+                    }
+                """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
+
+    // GETメソッドでクエリパラメータで年齢を指定しない時に、ユーザーが全件取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void 年齢を指定しない時にユーザーが全件取得できること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    [
+                    {
+                    "id": 1, 
+                    "name": "tanaka", 
+                    "age": 25
+                    }, 
+                    {
+                    "id": 2, 
+                    "name": "suzuki", 
+                    "age": 30
+                    }, 
+                    {
+                    "id": 3, 
+                    "name": "yamada", 
+                    "age": 35
+                    }
+                    ]                    
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでDBが空の時に、空のListが返されステータスコード200が返されること
+    @Test
+    @DataSet(value = "empty.yml")
+    @Transactional
+    void DBが空の時に空のListが返されること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                    []                    
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでクエリパラメータで年齢を指定した時に、指定した年齢より上のユーザーが取得できステータスコード200が返されること
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void 指定した年齢より上のユーザーが取得できること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users?age=30"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                [
+                {
+                "id": 3, 
+                "name": "yamada", 
+                "age": 35
+                }
+                ]
+            """, response, JSONCompareMode.STRICT);
+    }
+
+    // GETメソッドでクエリパラメータで年齢を指定し指定した年齢より上のユーザーが存在しない時に、空のListとステータスコード200が返されること
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void 指定した年齢より上のユーザーが存在しない時に空のListが返されること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/users?age=35"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                []
+            """, response, JSONCompareMode.STRICT);
+    }
+
+    // POSTメソッドで正しくリクエストした時に、ユーザーが登録できステータスコード201とメッセージが返されること
+
+    // POSTメソッドでリクエストのnameがnullの時に、ステータスコード400とエラーメッセージが返されること
+
+    // POSTメソッドでリクエストのageがnullの時に、ステータスコード400とエラーメッセージが返されること
+
+    // PATCHメソッドで存在するIDを指定した時に、ユーザーが更新できステータスコード200とメッセージが返されること
+
+    // PATCHメソッドで存在するIDを指定しリクエストのnameがnullの時に、ageのみ更新されステータスコード200とメッセージが返されること
+
+    // PATCHメソッドで存在するIDを指定しリクエストのageがnullの時に、nameのみ更新されステータスコード200とメッセージが返されること
+
+    // PATCHメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+
+    // DELETEメソッドで存在するIDを指定した時に、ユーザーが削除できステータスコード200とメッセージが返されること
+
+    // DELETEメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+
+}

--- a/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/com/example/lecture09task/integrationtest/UserRestApiIntegrationTest.java
@@ -336,7 +336,42 @@ public class UserRestApiIntegrationTest {
     }
 
     // DELETEメソッドで存在するIDを指定した時に、ユーザーが削除できステータスコード200とメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @ExpectedDataSet(value = "datasets/delete_users.yml")
+    @Transactional
+    void ユーザーが削除できること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/users/3"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+            {
+            "message": "user successfully deleted"
+            }
+            """, response, JSONCompareMode.STRICT);
+    }
 
     // DELETEメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
+    @Test
+    @DataSet(value = "datasets/users.yml")
+    @Transactional
+    void 削除リクエストで指定したIDのユーザーが存在しない時に例外がスローされること() throws Exception{
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/users/4"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
+        JSONAssert.assertEquals("""
+                    {
+                    "timestamp": "2023-06-05T18:13:22.414491+09:00[Asia/Tokyo]",
+                    "status": "404",
+                    "error": "Not Found",
+                    "message": "This id is not found",
+                    "path": "/users/4"
+                    }
+                """,
+                response,
+                new CustomComparator(JSONCompareMode.STRICT,
+                        new Customization("timestamp", ((o1, o2) -> true))));
+    }
 }

--- a/src/test/resources/datasets/update_users_age.yml
+++ b/src/test/resources/datasets/update_users_age.yml
@@ -1,0 +1,10 @@
+users:
+  - id: 1
+    name: "tanaka"
+    age: 25
+  - id: 2
+    name: "suzuki"
+    age: 30
+  - id: 3
+    name: "yamada"
+    age: 40

--- a/src/test/resources/datasets/update_users_name.yml
+++ b/src/test/resources/datasets/update_users_name.yml
@@ -1,0 +1,10 @@
+users:
+  - id: 1
+    name: "tanaka"
+    age: 25
+  - id: 2
+    name: "suzuki"
+    age: 30
+  - id: 3
+    name: "takahashi"
+    age: 35


### PR DESCRIPTION
## 概要
結合テストを実装しました。

## テスト項目
・GETメソッドで存在するIDを指定した時に、指定したIDのユーザーが取得できステータスコード200が返されること
・GETメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること
・GETメソッドでクエリパラメータで年齢を指定しない時に、ユーザーが全件取得できステータスコード200が返されること
・GETメソッドでDBが空の時に、空のListが返されステータスコード200が返されること
・GETメソッドでクエリパラメータで年齢を指定した時に、指定した年齢より上のユーザーが取得できステータスコード200が返されること
・GETメソッドでクエリパラメータで年齢を指定し指定した年齢より上のユーザーが存在しない時に、空のListとステータスコード200が返されること

・POSTメソッドで正しくリクエストした時に、ユーザーが登録できステータスコード201とメッセージが返されること
・POSTメソッドでリクエストのnameがnullの時に、ステータスコード400とエラーメッセージが返されること
・POSTメソッドでリクエストのageがnullの時に、ステータスコード400とエラーメッセージが返されること

・PATCHメソッドで存在するIDを指定した時に、ユーザーが更新できステータスコード200とメッセージが返されること
・PATCHメソッドで存在するIDを指定しリクエストのnameがnullの時に、ageのみ更新されステータスコード200とメッセージが返されること
・PATCHメソッドで存在するIDを指定しリクエストのageがnullの時に、nameのみ更新されステータスコード200とメッセージが返されること
・PATCHメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返される

・DELETEメソッドで存在するIDを指定した時に、ユーザーが削除できステータスコード200とメッセージが返されること
・DELETEメソッドで存在しないIDを指定した時に、例外がスローされステータスコード404とエラーメッセージが返されること